### PR TITLE
Fix install.xml path

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="qtype/mcq_chill/db" VERSION="20250518" COMMENT="Qtype MCQ Chill install XML">
+<XMLDB PATH="question/type/mcq_chill/db" VERSION="20250518" COMMENT="Qtype MCQ Chill install XML">
   <TABLES>
     <TABLE NAME="qtype_mcq_chill_options" COMMENT="Options spécifiques pour chaque question QCM Chill">
       <FIELDS>


### PR DESCRIPTION
## Summary
- fix path attribute in `db/install.xml`

## Testing
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
ET.parse('db/install.xml')
print('XML valid')
EOF`