### PR TITLE
Simplify QCM Chill editing form

### DIFF
--- a/edit_mcq_chill_form.php
+++ b/edit_mcq_chill_form.php
@@ -27,17 +27,42 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/question/type/multichoice/edit_multichoice_form.php');
 
 class qtype_mcq_chill_edit_form extends qtype_multichoice_edit_form {
+    /**
+     * Build the QCM Chill editing form.
+     * Only keep the question text, answers with checkboxes, negative marking
+     * and the all-or-nothing option.
+     *
+     * @param MoodleQuickForm $mform the form being built.
+     */
     protected function definition_inner($mform) {
-        parent::definition_inner($mform);
+        // Start from a clean form instead of the multichoice one.
+        // Question name and text are added by the base question_edit_form.
 
+        // Repeat answer fields with a checkbox indicating correct choices.
+        $repeated = [];
+        $repeated[] = $mform->createElement('text', 'answer[{no}]',
+            get_string('choicetext', 'qtype_mcq_chill'), ['size' => 40]);
+        $repeated[] = $mform->createElement('advcheckbox', 'fraction[{no}]', '',
+            get_string('correctanswer', 'qtype_mcq_chill'), [], [1, 0]);
+
+        $repeatedoptions = [];
+        $repeatedoptions['fraction[{no}]']['default'] = 0;
+
+        $this->repeat_elements($repeated, 4, $repeatedoptions, 'noanswers',
+            'addanswers', 1, get_string('addmoreanswerblanks', 'qtype_multichoice'));
+
+        // Dropdown for the negative mark applied to each wrong checkbox.
         $options = [];
         for ($i = -100; $i <= 0; $i++) {
-            $options[$i] = $i.'%';
+            $options[$i] = $i . '%';
         }
-        $mform->addElement('select', 'negativemarking', get_string('negativemarking', 'qtype_mcq_chill'), $options);
+        $mform->addElement('select', 'negativemarking',
+            get_string('negativemarking', 'qtype_mcq_chill'), $options);
         $mform->setDefault('negativemarking', 0);
 
-        $mform->addElement('advcheckbox', 'allornothing', get_string('allornothing', 'qtype_mcq_chill'));
+        // All or nothing option with help.
+        $mform->addElement('advcheckbox', 'allornothing',
+            get_string('allornothing', 'qtype_mcq_chill'));
         $mform->addHelpButton('allornothing', 'allornothing', 'qtype_mcq_chill');
     }
 
@@ -45,6 +70,14 @@ class qtype_mcq_chill_edit_form extends qtype_multichoice_edit_form {
         if (isset($question->options)) {
             $question->negativemarking = $question->options->negativemarking;
             $question->allornothing = $question->options->allornothing;
+            if (!empty($question->options->answers)) {
+                $i = 0;
+                foreach ($question->options->answers as $ans) {
+                    $question->answer[$i] = $ans->answer;
+                    $question->fraction[$i] = $ans->fraction > 0 ? 1 : 0;
+                    $i++;
+                }
+            }
         }
         parent::set_data($question);
     }
@@ -54,6 +87,14 @@ class qtype_mcq_chill_edit_form extends qtype_multichoice_edit_form {
         if (isset($question->options)) {
             $question->negativemarking = $question->options->negativemarking;
             $question->allornothing = $question->options->allornothing;
+            if (!empty($question->options->answers)) {
+                $i = 0;
+                foreach ($question->options->answers as $ans) {
+                    $question->answer[$i] = $ans->answer;
+                    $question->fraction[$i] = $ans->fraction > 0 ? 1 : 0;
+                    $i++;
+                }
+            }
         }
         return $question;
     }


### PR DESCRIPTION
## Summary
- build the editing form manually so only question text, answers with checkboxes, negative marking and all-or-nothing remain
- keep negative marking dropdown and all-or-nothing checkbox
- process answers so checkboxes are stored as fractions

## Testing
- `php -l edit_mcq_chill_form.php` *(fails: command not found)*